### PR TITLE
Use C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
+set (CMAKE_CXX_STANDARD 11)
 
 find_package(PkgConfig)
 find_package(SWIG 3.0.7 REQUIRED)


### PR DESCRIPTION
Node/V8 now use some C++11 features, like `constexpr`. Without this line, CMake can't compile correctly. I get:

```
/Users/calebegg/.cmake-js/node-x64/v10.8.0/include/node/v8.h:4587:10: error: 
      unknown type name 'constexpr'
  static constexpr size_t kMaxLength =
         ^
```